### PR TITLE
Remove stack trace printing to console.

### DIFF
--- a/src/main/java/net/wimpi/modbus/io/ModbusTCPTransport.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusTCPTransport.java
@@ -162,7 +162,7 @@ public class ModbusTCPTransport implements ModbusTransport {
             // connection reset by peer, also EOF
             throw new ModbusIOException(true);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            // ex.printStackTrace();
             throw new ModbusIOException("I/O exception - failed to read.");
         }
     }// readRequest
@@ -223,7 +223,7 @@ public class ModbusTCPTransport implements ModbusTransport {
              * return response;
              */
         } catch (Exception ex) {
-            ex.printStackTrace();
+            // ex.printStackTrace();
             throw new ModbusIOException(
                     String.format("I/O exception: %s %s", ex.getClass().getSimpleName(), ex.getMessage()));
         }

--- a/src/main/java/net/wimpi/modbus/io/ModbusUDPTransport.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusUDPTransport.java
@@ -106,7 +106,7 @@ public class ModbusUDPTransport implements ModbusTransport {
         } catch (InterruptedIOException ioex) {
             throw new ModbusIOException("Socket timed out.");
         } catch (Exception ex) {
-            ex.printStackTrace();
+            // ex.printStackTrace();
             throw new ModbusIOException("I/O exception - failed to read.");
         }
     }// readResponse


### PR DESCRIPTION
Connection and I/O errors were printed out to stdout. Now removed to clean out the output.

Also many logging statements very tuned to be less loud, as the errors are handled in the transport bundle.

cc @kaikreuzer 

I'm not sure how the release of this bundle really goes, hope you can execute the needed steps.

Signed-off-by: Sami Salonen <ssalonen@gmail.com>