### PR TITLE
Remove stacktrace print and reduce logging severity level

### DIFF
--- a/src/main/java/net/wimpi/modbus/io/ModbusRTUTransport.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusRTUTransport.java
@@ -167,8 +167,8 @@ public class ModbusRTUTransport extends ModbusSerialTransport {
             return response;
         } catch (Exception ex) {
             final String errMsg = "failed to read";
-            logger.error("Last request: {}", ModbusUtil.toHex(lastRequest));
-            logger.error("{}: {}", errMsg, ex.getMessage());
+            logger.debug("Last request: {}", ModbusUtil.toHex(lastRequest));
+            logger.debug("{}: {}", errMsg, ex.getMessage());
             throw new ModbusIOException(
                     String.format("I/O exception: %s %s", ex.getClass().getSimpleName(), ex.getMessage()));
         } finally {
@@ -228,7 +228,7 @@ public class ModbusRTUTransport extends ModbusSerialTransport {
                     out.write(inpBuf, 0, inpBytes);
                     m_CommPort.disableReceiveThreshold();
                     if (inpBytes != bc + 2) {
-                        logger.error("awaited {} bytes, but received {}", (bc + 2), inpBytes);
+                        logger.debug("awaited {} bytes, but received {}", (bc + 2), inpBytes);
                     }
                     break;
                 case 0x05:

--- a/src/main/java/net/wimpi/modbus/io/ModbusSerialTransaction.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusSerialTransaction.java
@@ -184,7 +184,8 @@ public class ModbusSerialTransaction implements ModbusTransaction {
                             try {
                                 Thread.sleep(m_TransDelayMS);
                             } catch (InterruptedException ex) {
-                                logger.error("InterruptedException: {}", ex.getMessage());
+                                logger.debug("InterruptedException: {}", ex.getMessage());
+                                throw;
                             }
                         }
 
@@ -195,12 +196,12 @@ public class ModbusSerialTransaction implements ModbusTransaction {
                         break;
                     } catch (ModbusIOException e) {
                         tries++;
-                        logger.error(
+                        logger.debug(
                                 "execute try {}/{} error: {}. Request: {} (unit id {} & transaction {}). Serial parameters: {}",
                                 tries, m_Retries + 1, e.getMessage(), m_Request, m_Request.getUnitID(),
                                 m_Request.getTransactionID(), m_SerialCon.getParameters());
                         if (tries >= m_Retries) {
-                            logger.error(
+                            logger.debug(
                                     "execute reached max tries {}, throwing last error: {}. Request: {} (unit id {} & transaction {}). Serial parameters: {}",
                                     m_Retries + 1, e.getMessage(), m_Request, m_Request.getUnitID(),
                                     m_Request.getTransactionID(), m_SerialCon.getParameters());
@@ -210,7 +211,7 @@ public class ModbusSerialTransaction implements ModbusTransaction {
                     }
                 } while (true);
                 if (tries > 0) {
-                    logger.info(
+                    logger.debug(
                             "execute eventually succeeded with {} re-tries. Request: {} (unit id {} & transaction id {}). Serial parameters: {}",
                             tries, m_Request, m_Request.getUnitID(), m_Request.getTransactionID(),
                             m_SerialCon.getParameters());

--- a/src/main/java/net/wimpi/modbus/io/ModbusSerialTransport.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusSerialTransport.java
@@ -141,7 +141,7 @@ abstract public class ModbusSerialTransport implements ModbusTransport {
         try {
             m_CommPort.enableReceiveThreshold(th); /* chars */
         } catch (UnsupportedCommOperationException e) {
-            logger.error("Failed to setReceiveThreshold: {}", e.getMessage());
+            logger.warn("Failed to setReceiveThreshold: {}", e.getMessage());
         }
     }
 
@@ -154,7 +154,7 @@ abstract public class ModbusSerialTransport implements ModbusTransport {
         try {
             m_CommPort.enableReceiveTimeout(ms); /* milliseconds */
         } catch (UnsupportedCommOperationException e) {
-            logger.error("Failed to setReceiveTimeout: {}", e.getMessage());
+            logger.warn("Failed to setReceiveTimeout: {}", e.getMessage());
         }
     }
 
@@ -177,7 +177,7 @@ abstract public class ModbusSerialTransport implements ModbusTransport {
         m_CommPort.disableReceiveThreshold();
         if (echoLen != len) {
             final String errMsg = "Echo not received";
-            logger.error("Transmit {}", errMsg);
+            logger.debug("Transmit {}", errMsg);
             throw new IOException(errMsg);
         }
     }// readEcho

--- a/src/main/java/net/wimpi/modbus/io/ModbusTCPTransaction.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusTCPTransaction.java
@@ -208,12 +208,12 @@ public class ModbusTCPTransaction implements ModbusTransaction {
                     break;
                 } catch (ModbusIOException ex) {
                     tries++;
-                    logger.error(
+                    logger.debug(
                             "execute try {}/{} error: {}. Request: {} (unit id {} & transaction {}). Address: {}:{}",
                             tries, m_Retries + 1, ex.getMessage(), m_Request, m_Request.getUnitID(),
                             m_Request.getTransactionID(), m_Connection.getAddress(), m_Connection.getPort());
                     if (tries >= m_Retries) {
-                        logger.error(
+                        logger.debug(
                                 "execute reached max tries {}, throwing last error: {}. Request: {} (unit id {} & transaction {}). Address: {}:{}",
                                 m_Retries + 1, ex.getMessage(), m_Request, m_Request.getUnitID(),
                                 m_Request.getTransactionID(), m_Connection.getAddress(), m_Connection.getPort());
@@ -225,7 +225,7 @@ public class ModbusTCPTransaction implements ModbusTransaction {
             } while (true);
 
             if (tries > 0) {
-                logger.info(
+                logger.debug(
                         "execute eventually succeeded with {} re-tries. Request: {} (unit id {} & transaction {}). Address: {}:{}",
                         tries, m_Request, m_Request.getUnitID(), m_Request.getTransactionID(),
                         m_Connection.getAddress(), m_Connection.getPort());

--- a/src/main/java/net/wimpi/modbus/io/ModbusTCPTransport.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusTCPTransport.java
@@ -162,7 +162,7 @@ public class ModbusTCPTransport implements ModbusTransport {
             // connection reset by peer, also EOF
             throw new ModbusIOException(true);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            // ex.printStackTrace();
             throw new ModbusIOException("I/O exception - failed to read.");
         }
     }// readRequest
@@ -223,7 +223,7 @@ public class ModbusTCPTransport implements ModbusTransport {
              * return response;
              */
         } catch (Exception ex) {
-            ex.printStackTrace();
+            // ex.printStackTrace();
             throw new ModbusIOException(
                     String.format("I/O exception: %s %s", ex.getClass().getSimpleName(), ex.getMessage()));
         }

--- a/src/main/java/net/wimpi/modbus/io/ModbusUDPTransport.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusUDPTransport.java
@@ -106,7 +106,7 @@ public class ModbusUDPTransport implements ModbusTransport {
         } catch (InterruptedIOException ioex) {
             throw new ModbusIOException("Socket timed out.");
         } catch (Exception ex) {
-            ex.printStackTrace();
+            // ex.printStackTrace();
             throw new ModbusIOException("I/O exception - failed to read.");
         }
     }// readResponse

--- a/src/main/java/net/wimpi/modbus/net/SerialConnection.java
+++ b/src/main/java/net/wimpi/modbus/net/SerialConnection.java
@@ -122,7 +122,7 @@ public class SerialConnection implements SerialPortEventListener, ModbusSlaveCon
             m_PortIdentifyer = CommPortIdentifier.getPortIdentifier(m_Parameters.getPortName());
         } catch (NoSuchPortException e) {
             final String errMsg = "Could not get port identifier, maybe insufficient permissions. " + e.getMessage();
-            logger.error("Could not get port identifier, maybe insufficient permissions. {}: {}",
+            logger.debug("Could not get port identifier, maybe insufficient permissions. {}: {}",
                     e.getClass().getName(), e.getMessage());
             throw new Exception(errMsg);
         }
@@ -133,7 +133,7 @@ public class SerialConnection implements SerialPortEventListener, ModbusSlaveCon
             m_SerialPort = m_PortIdentifyer.open("Modbus Serial Master", 30000);
         } catch (PortInUseException e) {
             String msg = "open port failed: " + e.getMessage();
-            logger.error("open port failed: {}: {}", e.getClass().getName(), e.getMessage());
+            logger.debug("open port failed: {}: {}", e.getClass().getName(), e.getMessage());
             throw new Exception(msg);
         }
         logger.trace("Got Serial Port");
@@ -144,7 +144,7 @@ public class SerialConnection implements SerialPortEventListener, ModbusSlaveCon
         } catch (Exception e) {
             // ensure it is closed
             m_SerialPort.close();
-            logger.error("parameter setup failed. {}: {}", e.getClass().getName(), e.getMessage());
+            logger.debug("parameter setup failed. {}: {}", e.getClass().getName(), e.getMessage());
             throw e;
         }
 
@@ -169,7 +169,7 @@ public class SerialConnection implements SerialPortEventListener, ModbusSlaveCon
         } catch (IOException e) {
             m_SerialPort.close();
             String msg = "Error opening i/o streams: " + e.getMessage();
-            logger.error("Error opening i/o streams. {}: {}", e.getClass().getName(), e.getMessage());
+            logger.debug("Error opening i/o streams. {}: {}", e.getClass().getName(), e.getMessage());
             throw new Exception(msg);
         }
         logger.trace("i/o Streams prepared");
@@ -180,7 +180,7 @@ public class SerialConnection implements SerialPortEventListener, ModbusSlaveCon
         } catch (TooManyListenersException e) {
             m_SerialPort.close();
             final String errMsg = "too many listeners added:" + e.getMessage();
-            logger.error("too many listeners added. {}: {}", e.getClass().getName(), e.getMessage());
+            logger.debug("too many listeners added. {}: {}", e.getClass().getName(), e.getMessage());
             throw new Exception(errMsg);
         }
 
@@ -196,7 +196,7 @@ public class SerialConnection implements SerialPortEventListener, ModbusSlaveCon
         try {
             m_SerialPort.enableReceiveTimeout(ms);
         } catch (UnsupportedCommOperationException e) {
-            logger.error("Failed to set receive timeout: {}", e.getMessage());
+            logger.warn("Failed to set receive timeout: {}", e.getMessage());
         }
     }// setReceiveTimeout
 
@@ -261,13 +261,13 @@ public class SerialConnection implements SerialPortEventListener, ModbusSlaveCon
         try {
             m_Transport.close();
         } catch (IOException e) {
-            logger.error("Error occurred when closing transport. {}: {}", e.getClass().getName(), e.getMessage());
+            logger.warn("Error occurred when closing transport. {}: {}", e.getClass().getName(), e.getMessage());
         }
 
         try {
             m_SerialIn.close();
         } catch (IOException e) {
-            logger.error("Error occurred when closing serial input stream. {}: {}", e.getClass().getName(),
+            logger.warn("Error occurred when closing serial input stream. {}: {}", e.getClass().getName(),
                     e.getMessage());
         }
 

--- a/src/main/java/net/wimpi/modbus/net/TCPMasterConnection.java
+++ b/src/main/java/net/wimpi/modbus/net/TCPMasterConnection.java
@@ -107,7 +107,7 @@ public class TCPMasterConnection implements ModbusSlaveConnection {
             try {
                 m_ModbusTransport.close();
             } catch (IOException ex) {
-                logger.debug("close()");
+                logger.warn("close()", ex);
             }
             m_Connected = false;
         }
@@ -157,7 +157,7 @@ public class TCPMasterConnection implements ModbusSlaveConnection {
             try {
                 m_Socket.setSoTimeout(m_Timeout);
             } catch (IOException ex) {
-                logger.error("Could not set socket timeout on connection {} {}: {}", getAddress(), getPort(),
+                logger.warn("Could not set socket timeout on connection {} {}: {}", getAddress(), getPort(),
                         ex.getMessage());
             }
         }

--- a/src/main/java/net/wimpi/modbus/net/TCPSlaveConnection.java
+++ b/src/main/java/net/wimpi/modbus/net/TCPSlaveConnection.java
@@ -67,7 +67,7 @@ public class TCPSlaveConnection {
             setSocket(socket);
         } catch (IOException ex) {
             final String errMsg = "Socket invalid";
-            logger.debug(errMsg);
+            logger.warn(errMsg);
             // @commentstart@
             throw new IllegalStateException(errMsg);
             // @commentend@


### PR DESCRIPTION
Connection and I/O errors were printed out to stdout. Now removed to clean out the output.

Also many logging statements very tuned to be less loud, as the errors are handled in the transport bundle.

cc @kaikreuzer

I'm not sure how the release of this bundle really goes, hope you can execute the needed steps.

Signed-off-by: Sami Salonen ssalonen@gmail.com