### PR TITLE
Changed read to readFully in TCP transports to get rid of fragmented packets

### DIFF
--- a/src/main/java/net/wimpi/modbus/io/ModbusTCPRTUTransport.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusTCPRTUTransport.java
@@ -158,7 +158,6 @@ public class ModbusTCPRTUTransport extends ModbusTCPTransport {
 
     private void getResponse(int fn, BytesOutputStream out) throws IOException {
         int bc = -1, bc2 = -1, bcw = -1;
-        int inpBytes = 0;
         byte inpBuf[] = new byte[256];
 
         switch (fn) {
@@ -175,11 +174,8 @@ public class ModbusTCPRTUTransport extends ModbusTCPTransport {
                 bc = m_Input.read();
                 out.write(bc);
                 // now get the specified number of bytes and the 2 CRC bytes
-                inpBytes = m_Input.read(inpBuf, 0, bc + 2);
-                out.write(inpBuf, 0, inpBytes);
-                if (inpBytes != bc + 2) {
-                    logger.debug("awaited {} bytes, but received {}", (bc + 2), inpBytes);
-                }
+                m_Input.readFully(inpBuf, 0, bc + 2);
+                out.write(inpBuf, 0, bc + 2);
                 break;
             case 0x05:
             case 0x06:
@@ -187,19 +183,19 @@ public class ModbusTCPRTUTransport extends ModbusTCPTransport {
             case 0x0F:
             case 0x10:
                 // read status: only the CRC remains after address and function code
-                inpBytes = m_Input.read(inpBuf, 0, 6);
-                out.write(inpBuf, 0, inpBytes);
+                m_Input.readFully(inpBuf, 0, 6);
+                out.write(inpBuf, 0, 6);
                 break;
             case 0x07:
             case 0x08:
                 // read status: only the CRC remains after address and function code
-                inpBytes = m_Input.read(inpBuf, 0, 3);
-                out.write(inpBuf, 0, inpBytes);
+                m_Input.readFully(inpBuf, 0, 3);
+                out.write(inpBuf, 0, 3);
                 break;
             case 0x16:
                 // eight bytes in addition to the address and function codes
-                inpBytes = m_Input.read(inpBuf, 0, 8);
-                out.write(inpBuf, 0, inpBytes);
+                m_Input.readFully(inpBuf, 0, 8);
+                out.write(inpBuf, 0, 8);
                 break;
             case 0x18:
                 // read the byte count word
@@ -209,8 +205,8 @@ public class ModbusTCPRTUTransport extends ModbusTCPTransport {
                 out.write(bc2);
                 bcw = ModbusUtil.makeWord(bc, bc2);
                 // now get the specified number of bytes and the 2 CRC bytes
-                inpBytes = m_Input.read(inpBuf, 0, bcw + 2);
-                out.write(inpBuf, 0, inpBytes);
+                m_Input.readFully(inpBuf, 0, bcw + 2);
+                out.write(inpBuf, 0, bcw + 2);
                 break;
         }
     }// getResponse

--- a/src/main/java/net/wimpi/modbus/io/ModbusTCPTransport.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusTCPTransport.java
@@ -132,15 +132,11 @@ public class ModbusTCPTransport implements ModbusTransport {
                 byte[] buffer = m_ByteIn.getBuffer();
 
                 // read to byte length of message
-                if (m_Input.read(buffer, 0, 6) == -1) {
-                    throw new EOFException("Premature end of stream (Header truncated).");
-                }
+                m_Input.readFully(buffer, 0, 6);
                 // extract length of bytes following in message
                 int bf = ModbusUtil.registerToShort(buffer, 4);
                 // read rest
-                if (m_Input.read(buffer, 6, bf) == -1) {
-                    throw new ModbusIOException("Premature end of stream (Message truncated).");
-                }
+                m_Input.readFully(buffer, 6, bf);
                 m_ByteIn.reset(buffer, (6 + bf));
                 m_ByteIn.skip(7);
                 int functionCode = m_ByteIn.readUnsignedByte();


### PR DESCRIPTION
As discussed here https://github.com/openhab/jamod/pull/10 i've checked if we change `read` to `readFully` when appropriate and let socket handle the timeout. And without surprises, it works. 

Also, i've had a look at `SerialTransport` and it seems `enableReceiveTimeout` is enough for there. As stated in docs https://docs.oracle.com/cd/E17802_01/products/products/javacomm/reference/api/javax/comm/CommPort.html#enableReceiveTimeout(int) timeout makes `read` call return, not throw an exception, so changing to `readFully` could lead to unwanted hangup.