### PR TITLE
Added request for full list of CommPortIdentifiers if we're unable to get identifer by name.

### DIFF
--- a/src/main/java/net/wimpi/modbus/net/SerialConnection.java
+++ b/src/main/java/net/wimpi/modbus/net/SerialConnection.java
@@ -56,6 +56,7 @@ public class SerialConnection implements SerialPortEventListener, ModbusSlaveCon
     private SerialPort m_SerialPort;
     private boolean m_Open;
     private InputStream m_SerialIn;
+    private boolean m_PortsRequested;
 
     /**
      * Creates a SerialConnection object and initializes variables passed in
@@ -66,6 +67,7 @@ public class SerialConnection implements SerialPortEventListener, ModbusSlaveCon
     public SerialConnection(SerialParameters parameters) {
         m_Parameters = parameters;
         m_Open = false;
+        m_PortsRequested = false;
     }// constructor
 
     /**
@@ -111,7 +113,15 @@ public class SerialConnection implements SerialPortEventListener, ModbusSlaveCon
 
         // 1. obtain a CommPortIdentifier instance
         try {
-            m_PortIdentifyer = CommPortIdentifier.getPortIdentifier(m_Parameters.getPortName());
+            try {
+                m_PortIdentifyer = CommPortIdentifier.getPortIdentifier(m_Parameters.getPortName());
+            } catch (NoSuchPortException e) {
+                if (!m_PortsRequested) {
+                    CommPortIdentifier.getPortIdentifiers();
+                } else {
+                    throw e;
+                }
+            }
         } catch (NoSuchPortException e) {
             final String errMsg = "Could not get port identifier, maybe insufficient permissions. " + e.getMessage();
             logger.debug("Could not get port identifier, maybe insufficient permissions. {}: {}",


### PR DESCRIPTION
Hello!

I was receiving a problem of OpenHAB being to unable to open COM port under OpenSUSE Linux (detailed explanation and what i've tried is here https://community.openhab.org/t/modbus-binding-does-not-see-serial-port/118527).

More exactly, there was these errors in logfiles:
```
2021-03-16 22:58:03.774 [ERROR] [ing.ModbusSlaveConnectionFactoryImpl] - Error connecting connection SerialConnection [m_SerialPort=null, m_Parameters.getPortName()=/dev/ttyACM0] for endpoint ModbusSerialSlaveEndpoint [getPortName()=/dev/ttyACM0]: Could not get port identifier, maybe insufficient permissions. null
2021-03-16 22:58:03.774 [WARN ] [rt.modbus.internal.ModbusManagerImpl] - Could not connect to endpoint ModbusSerialSlaveEndpoint [getPortName()=/dev/ttyACM0] -- aborting request ModbusReadRequestBlueprint [slaveId=1, functionCode=READ_MULTIPLE_REGISTERS, start=0, length=10, maxTries=3] [operation ID f676e96f-e379-43e1-8757-325f65c2caac]
2021-03-16 22:58:04.279 [WARN ] [ing.ModbusSlaveConnectionFactoryImpl] - connect try 1/1 error: Could not get port identifier, maybe insufficient permissions. null. Connection SerialConnection [m_SerialPort=null, m_Parameters.getPortName()=/dev/ttyACM0]. Endpoint ModbusSerialSlaveEndpoint [getPortName()=/dev/ttyACM0]
2021-03-16 22:58:04.279 [ERROR] [ing.ModbusSlaveConnectionFactoryImpl] - re-connect reached max tries 1, throwing last error: Could not get port identifier, maybe insufficient permissions. null. Connection SerialConnection [m_SerialPort=null, m_Parameters.getPortName()=/dev/ttyACM0]. Endpoint ModbusSerialSlaveEndpoint [getPortName()=/dev/ttyACM0]
2021-03-16 22:58:04.279 [ERROR] [ing.ModbusSlaveConnectionFactoryImpl] - Error connecting connection SerialConnection [m_SerialPort=null, m_Parameters.getPortName()=/dev/ttyACM0] for endpoint ModbusSerialSlaveEndpoint [getPortName()=/dev/ttyACM0]: Could not get port identifier, maybe insufficient permissions. null
2021-03-16 22:58:04.279 [WARN ] [rt.modbus.internal.ModbusManagerImpl] - Could not connect to endpoint ModbusSerialSlaveEndpoint [getPortName()=/dev/ttyACM0] -- aborting request ModbusReadRequestBlueprint [slaveId=1, functionCode=READ_MULTIPLE_REGISTERS, start=0, length=10, maxTries=3] [operation ID 3f58640a-4d38-44e0-a37d-510b61d0ba7f]
2021-03-16 22:58:04.784 [WARN ] [ing.ModbusSlaveConnectionFactoryImpl] - connect try 1/1 error: Could not get port identifier, maybe insufficient permissions. null. Connection SerialConnection [m_SerialPort=null, m_Parameters.getPortName()=/dev/ttyACM0]. Endpoint ModbusSerialSlaveEndpoint [getPortName()=/dev/ttyACM0]
2021-03-16 22:58:04.784 [ERROR] [ing.ModbusSlaveConnectionFactoryImpl] - re-connect reached max tries 1, throwing last error: Could not get port identifier, maybe insufficient permissions. null. Connection SerialConnection [m_SerialPort=null, m_Parameters.getPortName()=/dev/ttyACM0]. Endpoint ModbusSerialSlaveEndpoint [getPortName()=/dev/ttyACM0]
2021-03-16 22:58:04.784 [ERROR] [ing.ModbusSlaveConnectionFactoryImpl] - Error connecting connection SerialConnection [m_SerialPort=null, m_Parameters.getPortName()=/dev/ttyACM0] for endpoint ModbusSerialSlaveEndpoint [getPortName()=/dev/ttyACM0]: Could not get port identifier, maybe insufficient permissions. null
2021-03-16 22:58:04.784 [WARN ] [rt.modbus.internal.ModbusManagerImpl] - Could not connect to endpoint ModbusSerialSlaveEndpoint [getPortName()=/dev/ttyACM0] -- aborting request ModbusReadRequestBlueprint [slaveId=1, functionCode=READ_MULTIPLE_REGISTERS, start=0, length=10, maxTries=3] [operation ID dd687ef2-12d0-470d-b3ef-0f59b2ffdb64]
```

After poking the code for some time it seems to me, that `CommPortIdentifier` class could return null for existing port if there was no call to `getCommPortIdentifiers()` before calling `getCommPortIdentifier(String)` (that is because is has internal list of ports with head in `CommPortIndex` variable and this list is filled only when `getCommPortIdentifiers()` is called).

So, i'm suggesting a bit ugly but tiny workaround for that problem. I've tested it in my environment and it works after fix.