### PR TITLE
Modbus TCP client to read full messages, even if fragmented/segmented

### DIFF
--- a/src/main/java/net/wimpi/modbus/io/ModbusTCPTransport.java
+++ b/src/main/java/net/wimpi/modbus/io/ModbusTCPTransport.java
@@ -192,15 +192,11 @@ public class ModbusTCPTransport implements ModbusTransport {
                 byte[] buffer = m_ByteIn.getBuffer();
 
                 // read to byte length of message
-                if (m_Input.read(buffer, 0, 6) == -1) {
-                    throw new ModbusIOException("Premature end of stream (Header truncated).");
-                }
+                m_Input.readFully(buffer, 0, 6);
                 // extract length of bytes following in message
                 int bf = ModbusUtil.registerToShort(buffer, 4);
                 // read rest
-                if (m_Input.read(buffer, 6, bf) == -1) {
-                    throw new ModbusIOException("Premature end of stream (Message truncated).");
-                }
+                m_Input.readFully(buffer, 6, bf);
                 m_ByteIn.reset(buffer, (6 + bf));
                 m_ByteIn.skip(7);
                 int functionCode = m_ByteIn.readUnsignedByte();


### PR DESCRIPTION
Additional correction to PR #11. PR #11 Only fixed Modbus TCP server
implementation (readRequest). This is not used in openHAB binding at
all.

Pre-compiled modbus transport that uses this version of jamod: 
[org.openhab.core.io.transport.modbus-3.1.0-2021-04-20-tcp-transport-fix-SNAPSHOT.zip](https://github.com/openhab/jamod/files/6345487/org.openhab.core.io.transport.modbus-3.1.0-2021-04-20-tcp-transport-fix-SNAPSHOT.zip)

Intention to fix SMA inverter behaviour which seems to split the modbus response in multiple tcp packets. Apparently this seems to be rare otherwise. See  https://community.openhab.org/t/modbus-binding-with-sma-inverter-missing-lower-byte/119467/29 and https://github.com/openhab/openhab-addons/issues/5347 . 

TODO
- [ ] Wait for user test from https://community.openhab.org/t/modbus-binding-with-sma-inverter-missing-lower-byte/119467/29 and https://github.com/openhab/openhab-addons/issues/5347


Signed-off-by: Sami Salonen <ssalonen@gmail.com>