### PR TITLE
Have OH version suffix to signal that this repo is a jamod fork for openHAB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>net.wimpi</groupId>
 	<artifactId>jamod</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.3-SNAPSHOT</version>
+	<version>1.3.3.OH-SNAPSHOT</version>
 	<name>jamod</name>
 	<url>http://jamod.sourceforge.net</url>
 	<description>


### PR DESCRIPTION
Perhaps this was accidentally dropped in https://github.com/openhab/jamod/commit/79ba7e37bc6c7e795b806ad60dc6b8134a206306

Signed-off-by: Sami Salonen <ssalonen@gmail.com>